### PR TITLE
Update float-help.pd

### DIFF
--- a/doc/5.reference/float-help.pd
+++ b/doc/5.reference/float-help.pd
@@ -1,42 +1,92 @@
-#N canvas 605 89 582 514 12;
-#X msg 44 160 bang;
-#X obj 45 378 float 6.5;
-#X floatatom 45 408 0 0 0 0 - - - 0;
-#X floatatom 56 186 0 0 0 0 - - - 0;
-#X floatatom 105 348 0 0 0 0 - - - 0;
+#N canvas 406 36 607 635 12;
+#X msg 44 129 bang;
+#X obj 45 347 float 6.5;
+#X floatatom 45 377 0 0 0 0 - - - 0;
+#X floatatom 56 155 0 0 0 0 - - - 0;
+#X floatatom 105 317 0 0 0 0 - - - 0;
 #X obj 57 15 float;
-#X text 33 76 The float object stores a number \, initialized by its
+#X text 28 57 The float object stores a number \, initialized by its
 creation argument \, which may be reset using its inlet and output
 by sending it the "bang" message. Sending a number sets a new value
-and outputs it., f 61;
-#X text 140 350 sets the value;
-#X text 123 379 creation argument initializes the value;
-#X floatatom 444 230 5 0 0 0 - - - 0;
-#X text 89 161 output the value;
-#X text 86 185 set and output the value;
-#X obj 444 206 r float-help;
-#X msg 61 215 send float-help;
-#X obj 79 281 makefilename %f;
-#X msg 79 257 42.23;
-#X text 198 272 symbols that look like floats are converted., f 23
+and outputs it., f 71;
+#X text 140 319 sets the value;
+#X text 123 348 creation argument initializes the value;
+#X floatatom 436 152 5 0 0 0 - - - 0;
+#X text 89 130 output the value;
+#X text 86 154 set and output the value;
+#X obj 436 128 r float-help;
+#X msg 68 185 send float-help;
+#X obj 79 250 makefilename %f;
+#X msg 79 226 42.23;
+#X text 198 241 symbols that look like floats are converted., f 23
 ;
-#X symbolatom 79 307 10 0 0 0 - - - 0;
-#X text 156 307 <= type a number on a symbol box;
-#X text 345 452 updated for Pd version 0.48;
-#X text 35 454 see also:;
-#X obj 192 455 value;
-#X obj 238 455 send;
-#X floatatom 451 301 5 0 0 0 - - - 0;
-#X obj 451 277 v float-help;
-#X obj 451 257 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#X symbolatom 79 276 10 0 0 0 - - - 0;
+#X text 156 276 <= type a number on a symbol box;
+#X text 346 590 updated for Pd version 0.48;
+#X text 36 592 see also:;
+#X obj 193 593 value;
+#X obj 239 593 send;
+#X floatatom 437 225 5 0 0 0 - - - 0;
+#X obj 437 201 v float-help;
+#X obj 437 181 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
 #000000 #000000;
-#X text 182 216 send to a named object such as a;
-#X text 306 236 receive or value:;
-#X obj 109 455 int;
+#X obj 110 593 int;
 #X text 99 14 - store a (floating point) number;
-#X obj 57 43 f;
-#X text 89 44 - abbreviation;
-#X obj 140 455 symbol;
+#X obj 356 15 f;
+#X text 388 15 - abbreviation;
+#X obj 141 593 symbol;
+#N canvas 995 162 565 399 Dealing_with_"\$0" 0;
+#X text 36 33 '\$0' - the patch ID number used to force locality in
+Pd - is widely used in send and receive names \, speacially in abstractions
+so each copy has local connections instead of global., f 67;
+#X floatatom 341 339 5 0 0 0 - - - 0;
+#X obj 149 295 float 1.5;
+#X msg 149 257 send \$1-x;
+#X obj 149 225 f \$0;
+#X obj 149 198 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X obj 288 221 value \$0-x;
+#X obj 288 192 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X floatatom 288 256 5 0 0 0 - - - 0;
+#X floatatom 390 221 5 0 0 0 - #0-x - 0;
+#X msg 44 254 send \$1;
+#X obj 44 200 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000;
+#X obj 44 225 symbol \$0-y;
+#X obj 341 298 receive \$0-y;
+#X text 435 220 <= right click for properties, f 10;
+#X text 33 99 Since "\$0" only works inside objects \, if you need
+to set a send name with it \, you need to use something like a symbol
+or a float object. Note that "\$0" is also used in send/receive names
+in GUIs as well as variable names in value objects., f 68;
+#X connect 3 0 2 0;
+#X connect 4 0 3 0;
+#X connect 5 0 4 0;
+#X connect 6 0 8 0;
+#X connect 7 0 6 0;
+#X connect 10 0 2 0;
+#X connect 11 0 12 0;
+#X connect 12 0 10 0;
+#X connect 13 0 1 0;
+#X restore 383 532 pd Dealing_with_"\$0";
+#X floatatom 437 257 5 0 0 0 - float-help - 0;
+#X text 483 257 <= right click for properties, f 10;
+#X text 186 179 send to a named object such as a GUI \, a receive or
+value objects =>, f 34;
+#X text 196 519 open subpatch to see how to deal with '\$0' ======>
+, f 25;
+#X obj 44 425 100;
+#X obj 108 425 f 100;
+#X obj 44 456 \$0;
+#X obj 108 456 f \$0;
+#X text 170 423 <-- notice that due to the way pd manages float's selector
+\, when you type a float alone in an object box \, pd actually creates
+a float object \, so these objects are actually equivalent (but for
+better readability \, it is encouraged to always put "f" or "float"
+to create a float object);
+#X text 13 487 possible...;
+#X text 103 488 better!!;
 #X connect 0 0 1 0;
 #X connect 1 0 2 0;
 #X connect 3 0 1 0;

--- a/doc/5.reference/float-help.pd
+++ b/doc/5.reference/float-help.pd
@@ -1,4 +1,4 @@
-#N canvas 406 36 607 635 12;
+#N canvas 406 36 607 651 12;
 #X msg 44 129 bang;
 #X obj 45 347 float 6.5;
 #X floatatom 45 377 0 0 0 0 - - - 0;
@@ -22,19 +22,19 @@ and outputs it., f 71;
 ;
 #X symbolatom 79 276 10 0 0 0 - - - 0;
 #X text 156 276 <= type a number on a symbol box;
-#X text 346 590 updated for Pd version 0.48;
-#X text 36 592 see also:;
-#X obj 193 593 value;
-#X obj 239 593 send;
+#X text 346 610 updated for Pd version 0.48;
+#X text 36 612 see also:;
+#X obj 193 613 value;
+#X obj 239 613 send;
 #X floatatom 437 225 5 0 0 0 - - - 0;
 #X obj 437 201 v float-help;
 #X obj 437 181 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
 #000000 #000000;
-#X obj 110 593 int;
+#X obj 110 613 int;
 #X text 99 14 - store a (floating point) number;
 #X obj 356 15 f;
 #X text 388 15 - abbreviation;
-#X obj 141 593 symbol;
+#X obj 141 613 symbol;
 #N canvas 995 162 565 399 Dealing_with_"\$0" 0;
 #X text 36 33 '\$0' - the patch ID number used to force locality in
 Pd - is widely used in send and receive names \, speacially in abstractions
@@ -69,24 +69,27 @@ in GUIs as well as variable names in value objects., f 68;
 #X connect 11 0 12 0;
 #X connect 12 0 10 0;
 #X connect 13 0 1 0;
-#X restore 383 532 pd Dealing_with_"\$0";
+#X restore 383 572 pd Dealing_with_"\$0";
 #X floatatom 437 257 5 0 0 0 - float-help - 0;
 #X text 483 257 <= right click for properties, f 10;
 #X text 186 179 send to a named object such as a GUI \, a receive or
 value objects =>, f 34;
-#X text 196 519 open subpatch to see how to deal with '\$0' ======>
+#X text 196 559 open subpatch to see how to deal with '\$0' ======>
 , f 25;
-#X obj 44 425 100;
-#X obj 108 425 f 100;
-#X obj 44 456 \$0;
-#X obj 108 456 f \$0;
-#X text 170 423 <-- notice that due to the way pd manages float's selector
+#X obj 44 415 100;
+#X obj 108 415 f 100;
+#X obj 44 446 \$0;
+#X obj 108 446 f \$0;
+#X text 170 413 <-- notice that due to the way pd manages float's selector
 \, when you type a float alone in an object box \, pd actually creates
 a float object \, so these objects are actually equivalent (but for
 better readability \, it is encouraged to always put "f" or "float"
 to create a float object);
-#X text 13 487 possible...;
-#X text 103 488 better!!;
+#X text 13 477 possible...;
+#X text 103 478 better!!;
+#X obj 222 511 route;
+#X text 274 506 <-- also check route helpfile to read more about special
+selectors, f 33;
 #X connect 0 0 1 0;
 #X connect 1 0 2 0;
 #X connect 3 0 1 0;


### PR DESCRIPTION
Document Pd behaviour of creating a float object when the user types a float alone in an object box. But also suggests to always create floats with "f" or "float" for better readability

Edit: the second commit also suggests the user to read more about special selectors in the route helpfile, this is optional, check if it is a good idea to put it here in this context