### PR TITLE
more revisions

### DIFF
--- a/doc/1.manual/css/pdmanual.css
+++ b/doc/1.manual/css/pdmanual.css
@@ -113,28 +113,6 @@ KBD {
     font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
 }
 
-/*span.pdobj {
-    border: 1px solid black;
-    font-family: 'Menlo', monospace;
-    white-space: nowrap;
-    font-size: 90%;
-    padding: 2px;
-    margin: 0 4px;
-    font-weight: bolder;
-}*/
-
-
-span.pdobj {
-    font-weight: bolder;
-    white-space: nowrap;
-}
-span.pdobj::before {
-  content: "[";
-}
-span.pdobj::after {
-  content: "]";
-}
-
 /* standard link */
 
 a:link {

--- a/doc/1.manual/index.htm
+++ b/doc/1.manual/index.htm
@@ -40,7 +40,8 @@
                     <LI> <A href="x2.htm#s2.2.4">Delete, cut, copy and paste boxes</A>
                     <LI> <A href="x2.htm#s2.2.5">Changing the text of objects, messages and comments</A>
                     <LI> <A href="x2.htm#s2.2.6">Connecting and disconnecting boxes</A>
-                    <LI> <A href="x2.htm#s2.2.7">Popup menu for 'Properties', 'Open' and 'Help'</A>
+                    <LI> <A href="x2.htm#s2.2.7">Context menu for 'Properties', 'Open' and 'Help'</A>
+                    <LI> <A href="x2.htm#s2.2.8">Scrolling the patch area</A>
                 </OL>
             <LI> <A href="x2.htm#s2.3">Advanced patch editing</A>
                 <OL>

--- a/doc/1.manual/x1.htm
+++ b/doc/1.manual/x1.htm
@@ -174,7 +174,8 @@ in 2014. This used to come with a vast collection of externals. Many Pure Data t
 out there are based on this distribution. You can still follow Pd-extended tutorials if you
 install the necessary libraries, but note that these tutorials are very outdated
 and don't include many goodies that have been included in Pd Vanilla over the last years,
-like the [clone] object, [savestate], multichannel connections and many more.
+like the <b>[clone]</b> object, <b>[savestate]</b>,
+multichannel connections and many more.
 
 <P> The currently active and main flavors of Pd are presented on the front page
 of <A href="https://puredata.info/"> https://puredata.info/</A>. Note that some

--- a/doc/1.manual/x2.htm
+++ b/doc/1.manual/x2.htm
@@ -46,8 +46,8 @@ packages, refer to <A href="x4.htm"> Chapter 4: Externals</A>.
 <H4> <A id="s2.1.1"> 2.1.1. The main window, canvases, and printout</A> </H4>
 
 <P>Pd starts with the main "Pd" window. When you open a Pd document file you'll see a
-separate window, known in Pd as a <i>canvas</i> and also referred to as <i>patch</i>. The main Pd
-window looks like this:
+separate window, known in Pd as a <i>canvas</i> and also referred to as <i>patch</i>.
+The main Pd window looks like this:
 
 <figure>
 <IMG src="img/2.1.1.png" ALT="pd window">
@@ -85,7 +85,7 @@ boxes in patches and for messages from Pd itself. Here is a simple Pd patch:
 an <i>object box</i> labeled "print", plus two <i>comments</i> (which are simply texts
 that don't affect the patch and can't be connected to anything). The number
 box is connected to the object box, with the output of the number box feeding into
-the input of the <span class="pdobj">print</span> object box. Boxes may have zero or more inputs
+the input of the <b>[print]</b> object box. Boxes may have zero or more inputs
 and/or outputs, called <i>inlets</i> and <i>outlets</i>. Inlets are visible at the top of objects and outlets at their bottom. When clicking and dragging on the number box in run mode, the values are printed in the main "Pd" window.
 
 <P>On the upper right of the main Pd window, there is a <b>DSP</b> toggle, which stands
@@ -209,7 +209,7 @@ as well as words and names such as "Zack" or "cat". The symbols "gore", "Gore", 
 
 <P>The text you type into an object box determines how many and what kinds of
 <i>inlets</i> and <i>outlets</i> the object will have. Certain classes, such as
-<span class="pdobj">+</span>, consistently maintain a fixed configuration of inlets
+<b>[+]</b>, consistently maintain a fixed configuration of inlets
 and outlets. However, for other classes, the number and arrangement of inlets and
 outlets can vary based on the creation arguments.
 
@@ -221,25 +221,25 @@ synthesizes a pure tone:
     <figcaption>A simple MIDI synthesizer</figcaption>
 </figure>
 
-<P>This patch mixes <I>control</I> objects (<span class="pdobj">notein</span>,
-<span class="pdobj">stripnote</span>, and <span class="pdobj">ftom</span>) with <I>tilde</I>
-objects (<span class="pdobj">osc~</span>, <span class="pdobj">*~</span>, and
-<span class="pdobj">dac~</span>). These are the two types of objects that exist in Pd:
+<P>This patch mixes <I>control</I> objects (<b>[notein]</b>,
+<b>[stripnote]</b>, and <b>[ftom]</b>) with <I>tilde</I>
+objects (<b>[osc~]</b>, <b>[*~]</b>, and
+<b>[dac~]</b>). These are the two types of objects that exist in Pd:
 control objects and signal objects.
 
 <P>The control objects on the upper half carry out their function sporadically, as a
 result of one or more types of <I>events</I>. In this case, incoming MIDI note
 messages set off the control computation. When a note event happens (more
-specifically a "note on" event, since "note off" events are filtered by <span class="pdobj">stripnote</span>), the control computation is triggered and it computes the frequency in
-cycles per second with <span class="pdobj">mtof</span> and passes it on to the oscillator
-(<span class="pdobj">osc~</span>).
+specifically a "note on" event, since "note off" events are filtered by <b>[stripnote]</b>), the control computation is triggered and it computes the frequency in
+cycles per second with <b>[mtof]</b> and passes it on to the oscillator
+(<b>[osc~]</b>).
 
-<P>The objects in the lower half of the patch (<span class="pdobj">osc~</span>,
-<span class="pdobj">*~</span>, and <span class="pdobj">dac~</span>) compute
-audio samples. The <span class="pdobj">osc~</span> object serves as the interface
+<P>The objects in the lower half of the patch (<b>[osc~]</b>,
+<b>[*~]</b>, and <b>[dac~]</b>) compute
+audio samples. The <b>[osc~]</b> object serves as the interface
 between the two regimes; it takes control messages to set its frequency but outputs
-an audio sine wave to a gain level adjustment in <span class="pdobj">*~</span>,
-which then goes to the output via <span class="pdobj">dac~</span>.
+an audio sine wave to a gain level adjustment in <b>[*~]</b>,
+which then goes to the output via <b>[dac~]</b>.
 
 <P>The connections in the patch (the lines between the boxes) are also of the types
 "control" or "signal". Note that they are visually distinct, where signal connections
@@ -304,12 +304,12 @@ as well as close and save them.
 
 <P>When you save a patch to a file, Pd doesn't save the entire state of all the
 objects in the patch, but only what you see: the objects' creation arguments
-and their interconnections. Nonetheless, the <span class="pdobj">savestate</span>
+and their interconnections. Nonetheless, the <b>[savestate]</b>
 object offers a mechanism to save the state of abstractions (see
 <A href="x2.htm#s2.8">2.8. Subpatches</A>). Also, certain data-storage objects have
 functions for reading and writing files to save and restore their internal
-state (one example is the <span class="pdobj">text</span> object). When loading
-a patch, the <span class="pdobj">loadbang</span> object can be used to initialize
+state (one example is the <b>[text]</b> object). When loading
+a patch, the <b>[loadbang]</b> object can be used to initialize
 the parameters of your patch, so you can load text files and make other preparations.
 
 <P>Pd searches for files using specified paths. Most objects capable of reading files
@@ -443,13 +443,13 @@ You can also use <kbd>Shift</kbd>+<kbd>Arrow keys</kbd> to move items 10 pixels 
 desired direction. By the way, if you select boxes that are connected, the
 connections (patch cords) are also moved around.
 
-<P>The "Tidy Up" entry in the <b>Edit menu</b> allows you to try and align
+<P>The "Tidy Up" entry in the <b>Edit menu</b> allows you to align
 selected boxes that are not perfectly aligned. You can select boxes arranged in a
 horizontal row and use the shortcut <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd>
 to try and align them perfectly horizontally. Similarly, this can be applied to
 vertically align a column of boxes. Bidimensional rectangular selections of boxes
 are also possible, but aligning horizontally and vertically separately tends to yield
-better results.
+better results. When boxes are misaligned drastically, this action won't do anything.
 
 <figure>
 <IMG src="img/2.2.6.png" ALT="tidy up">
@@ -477,7 +477,7 @@ original selection remains in the original position).
 the operating system's clipboard. This limitation prevents you from pasting between
 different versions or flavors of Pure Data. Furthermore, it is not possible to copy
 from a patch and paste into a Pd subprocess that was instantiated through a
-<span class="pdobj">pd~</span> object.
+<b>[pd~]</b> object.
 
 <H4> <A id="s2.2.5">2.2.5. Changing the text of objects, messages and comments</A> </H4>
 
@@ -537,7 +537,7 @@ area and you can only select a single connection by clicking on it.
     <figcaption>Selecting a patch cord connection to delete it</figcaption>
 </figure>
 
-<H4> <A id="s2.2.7">2.2.7. Popup menu for "Properties", "Open" and "Help"</A> </H4>
+<H4> <A id="s2.2.7">2.2.7. Context menu for "Properties", "Open" and "Help"</A> </H4>
 
 <P>All the "clicking" mentioned above is done with the left mouse button.
 The right button, instead, opens a context menu offering "Properties",
@@ -559,6 +559,21 @@ Ordinary subpatches may also be opened by simply clicking on them, but for
 <P>The "Properties" dialog allows you to change certain settings of GUI
 boxes or of the patch itself (when clicking outside any box).
 
+<H4> <A id="s2.2.8">2.2.8. Scrolling the patch area</A> </H4>
+
+<P>Although it's good practice to work with <A href="x2.htm#s2.8">
+subpatches</A> and <A href="x2.htm#s2.8.1">abstractions</A> to keep patches easily
+comprehensible, they can grow outside the bounds of their window. When moving an
+object beyond the border, you'll see that scrollbars appear. Besides dragging the
+scrollbars, you can pan the patch vertically by turning the mousewheel and
+horizontally when pressing and holding <kbd>Shift</kbd> while doing so.
+On trackpads, you can use 2-finger scrub gestures to pan in all directions.
+
+<!-- INCLUDE IMG -->
+<!-- <figure>
+<IMG src="img/2.2.10.png" ALT="scrollbars">
+    <figcaption>Patch window with scrollbars</figcaption>
+</figure> -->
 
 <H3> <A id="s2.3">2.3. Advanced patch editing</A> </H3>
 
@@ -607,7 +622,7 @@ or <kbd>Shift</kbd>+<kbd>Tab</kbd> to navigate to the previous one.
 
 <P>By default, Pd has an "autopatching" mode set to on. You can disable it
 via startup flags (see "-autopatch" flag <a href="x3.htm#s3.4.1">3.4.1.
-Startup flags</A>). This works with the shortcuts from the <span class="pdobj">Put menu</span>
+Startup flags</A>). This works with the shortcuts from the <b>Put menu</b>
 for inserting boxes. If you have a selected box and use a shortcut to
 create another one (such as <kbd>Ctrl</kbd>+<kbd>1</kbd> to create an
 object box), the created box is placed below the selected box and a
@@ -619,7 +634,7 @@ and an inlet for the connection to happen).
 autopatching by adding yet more boxes. In the case of object and message boxes
 you can also start typing text into it before autopatching into another newly
 created box, since when you autopatch for the next one, the object or message
-box gets deselected and therefore created.
+box gets deselected and instantiated.
 
 <figure>
 <IMG src="img/2.3.4.png" ALT="autopatch objects">
@@ -629,9 +644,9 @@ box gets deselected and therefore created.
 
 <P>You can also autopatch into a newly created subpatch (see <A href="x2.htm#s2.8">
 2.8. Subpatches</A>). By creating an object box and typing "pd", as soon as you
-deselect the object, a <span class="pdobj">pd</span> subpatch is created with an
-inlet - either a control <span class="pdobj">inlet</span> if the object
-above is a control object, or a signal <span class="pdobj">inlet~</span> if
+deselect the object, a <b>[pd]</b> subpatch is created with an
+inlet - either a control <b>[inlet]</b> if the object
+above is a control object, or a signal <b>[inlet~]</b> if
 it is a tilde object instead.
 
 <figure>
@@ -729,7 +744,7 @@ boxes.
 
 <H4> <A id="s2.3.5">2.3.5. (Dis)Connect selection</A> </H4>
 
-<P>This is a menu entry in the <span class="pdobj">Edit menu</span>, also available via the shortcut
+<P>This is a menu entry in the <b>Edit menu</b>, also available via the shortcut
 <kbd>Ctrl</kbd>+<kbd>K</kbd>. It allows you to connect and disconnect selected
 boxes in different ways.
 
@@ -782,23 +797,26 @@ to include the third one in the connection.
 <H4> <A id="s2.3.6">2.3.6. Triggerize</A> </H4>
 
 <P>The "Triggerize" entry in the <b>Edit menu</b> (with the <kbd>Ctrl</kbd>+<kbd>T</kbd>
-shortcut) was designed to insert a <span class="pdobj">trigger</span> object (in its abbreviated form <span class="pdobj">t</span>) into
-your patch. Start by selecting a single box that is connected to many inlets (of one or
-more boxes), then use "Triggerize" to insert a <span class="pdobj">trigger</span> object after the selected object.
+shortcut) was designed to insert a <b>[trigger]</b> object (in its
+abbreviated form <b>[t]</b>) into your patch. Start by selecting a single
+box that is connected to many inlets (of one or more boxes), then use "Triggerize" to insert
+a <b>[trigger]</b> object after the selected object.
 
-<P>The <span class="pdobj">trigger</span> object is widely used in Pd to control the order of execution
-from right to left and is briefly described in <A href="x2.htm#s2.4.3">2.4.3.
-Hot and cold inlets and right to left outlet order</A>. "Triggerize" then creates
-the <span class="pdobj">trigger</span> object taking into account the order in which the connections were made,
-where the first connection starts at the rightmost outlet of <span class="pdobj">trigger</span> and continues to
-the leftmost.
+<P>The <b>[trigger]</b> object is widely used in Pd to control the order
+of execution from right to left and is briefly described in
+<A href="x2.htm#s2.4.3">2.4.3. Hot and cold inlets and right to left outlet order</A>.
+"Triggerize" then creates the <b>[trigger]</b> object taking into account
+the order in which the connections were made, where the first connection starts at the
+rightmost outlet of <b>[trigger]</b> and continues to the leftmost.
 
-<P>In the example below, a <span class="pdobj">pack</span> object is selected and connected to three <span class="pdobj">s</span> (<span class="pdobj">send</span>)
-objects. Triggerize then introduces <span class="pdobj">t a a a</span> (short for [trigger anything anything
-anything]) with three outlets and the order that the connections from <span class="pdobj">pack</span> were made
-reflect the order from right to left. You can swap connections with the <kbd>Shift</kbd>
-key (as described in subsection <A href="x2.htm#s2.3.4">2.3.4.</A>) if you need to adjust
-the order of connections.
+<P>In the example below, a <b>[pack]</b> object is selected and connected
+to three <b>[s]</b> (<b>[send]</b>) objects. Triggerize
+then introduces <b>[t a a a]</b> (short for
+<b>[trigger anything anything anything]</b>) with three outlets and the
+order that the connections from <b>[pack]</b> were made reflect the order
+from right to left. You can swap connections with the <kbd>Shift</kbd> key (as described
+in subsection <A href="x2.htm#s2.3.4">2.3.4.</A>) if you need to adjust the order of
+connections.
 
 <figure>
     <IMG src="img/2.3.19.png" ALT="triggerize object">
@@ -807,26 +825,27 @@ the order of connections.
 
 <P>Additionally, the "Triggerize" option can be used to insert a dummy object. To do so,
 select a connection and use <kbd>Ctrl</kbd>+<kbd>T</kbd>. For a control connection, a
-<span class="pdobj">t a</span> object is created with the text selected, so you can type
+<b>[t a]</b> object is created with the text selected, so you can type
 new text to create another object instead. Similarly, for a signal connection, a
-<span class="pdobj">pd nop~</span> ("no operation") subpatch is created.
+<b>[pd nop~]</b> ("no operation") subpatch is created.
 
 <figure>
     <IMG src="img/2.3.20.png" ALT="insert dummy">
     <figcaption>insert dummy</figcaption>
 </figure>
 
-<P>Triggerize also allows you to create or remove outlets of a selected <span class="pdobj">trigger</span>
-object. The result depends on the existing connections and outlets. As shown below,
-if each outlet has a single connection, it will insert an outlet on the left.
+<P>Triggerize also allows you to create or remove outlets of a selected
+<b>[trigger]</b> object. The result depends on the existing connections
+and outlets. As shown below, if each outlet has a single connection, it will insert an
+outlet on the left.
 
 <figure>
     <IMG src="img/2.3.21.png" ALT="add 1st outlet">
     <figcaption>add 1st outlet</figcaption>
 </figure>
 
-Now, if the <span class="pdobj">trigger</span> object has more outlets than outgoing connections,
-"Triggerize" removes the unused outlets.
+Now, if the <b>[trigger]</b> object has more outlets than outgoing
+connections, "Triggerize" removes the unused outlets.
 
 <figure>
     <IMG src="img/2.3.22.png" ALT="reduce outlets">
@@ -846,7 +865,7 @@ of the connections from right to left).
 
 <P>The "Paste Replace" entry in the <b>Edit menu</b> doesn't have a shortcut and performs
 a special paste operation where it replaces a selection of boxes for another kind. For
-example, first copy one box such as a <span class="pdobj">float</span> object. Then select
+example, first copy one box such as a <b>[float]</b> object. Then select
 a group of boxes of the same type, for instance, a group of object boxes (note that they
 don't need to be of the same class). Now go to the <b>Edit menu</b> and select "Paste
 Replace". All the selected boxes of the same type get replaced by the copied box and
@@ -857,7 +876,7 @@ connections are preserved.
     <figcaption>Paste replacing an object</figcaption>
 </figure>
 
-<P>Alternatively, you can copy a number box instead of a <span class="pdobj">float</span> object
+<P>Alternatively, you can copy a number box instead of a <b>[float]</b> object
 and replace it in the selected group of objects, or in a selected group
 of another kind, such as message boxes. Note that the box types in Pd
 are: objects, messages, GUIs and comments, whereas IEMguis are actually
@@ -895,7 +914,7 @@ is a symbol, which appears in the patch as a non-numeric string with no white
 space, semicolons, or commas. The arguments may be symbols or numbers.
 
 <P>Pd is usually compiled for single precision. Experimental binaries are
-available via the community for double precision (AKA: "Pd64"), but no
+available via the community for double precision (aka "Pd64"), but no
 binary is yet provided by the official download site. You can also compile
 Pd for double precision yourself (see details in <A href="x6.htm#s6.2">
 6.2. General Autotools Build steps</A>). If compiled for single precision,
@@ -942,13 +961,14 @@ selector, it carries out some corresponding action.
 
 <figure>
     <IMG src="img/2.4.1.png" ALT="float object">
-    <figcaption>A <span class="pdobj">float</span> object</figcaption>
+    <figcaption>A <b>[float]</b> object</figcaption>
 </figure>
 
-<P>For instance, in the <span class="pdobj">float</span> object above, we see two rectangles at the top that
-are called "inlets", but the one on the left directs incoming messages to the
-<span class="pdobj">float</span> object itself, while the one on the right directs messages to an auxiliary
-"inlet" object. The <span class="pdobj">float</span> object itself (represented by the left inlet) accepts
+<P>For instance, in the <b>[float]</b> object above, we see two
+rectangles at the top that are called "inlets", but the one on the left directs incoming
+messages to the <b>[float]</b> object itself, while the one on the
+right directs messages to an auxiliary "inlet" object. The
+<b>[float]</b> object itself (represented by the left inlet) accepts
 messages with the selectors "float" and "bang". The right inlet only accepts messages
 with the "float" selector. These two selectors, together with "symbol" and "list",
 are usually used to indicate the main action of an object, whatever it may be,
@@ -994,14 +1014,14 @@ on (as described earlier) to select the causing object. Note that you can also u
     <figcaption>Find error via the console window</figcaption>
 </figure>
 
-<P>However, it is legal to make a loop if there is a <span class="pdobj">delay</span>
-object somewhere in it. When <span class="pdobj">delay</span> receives a message, it
+<P>However, it is legal to make a loop if there is a <b>[delay]</b>
+object somewhere in it. When <b>[delay]</b> receives a message, it
 schedules a message for the future (even if the time delay is 0) and is then "finished";
-Pd's internal scheduler will wake the delay back up later.
+Pd's internal scheduler will wake the <b>[delay]</b> back up later.
 
 <H4> <A id="s2.4.3">2.4.3. Hot and cold inlets and right to left outlet order</A> </H4>
 
-<P>With few exceptions (notably <span class="pdobj">timer</span>), objects treat their leftmost
+<P>With few exceptions (notably <b>[timer]</b>), objects treat their leftmost
 inlet as <i>hot</i> in the sense that messages to left inlets can result in output
 messages. So the following is a legal (and reasonable) loop construct:
 
@@ -1010,24 +1030,24 @@ messages. So the following is a legal (and reasonable) loop construct:
     <figcaption>Avoiding infinite loop with a cold inlet</figcaption>
 </figure>
 
-<P>Here, the <span class="pdobj">f</span> object is an abbreviation for
-<span class="pdobj">float</span>. Note that the <span class="pdobj">+ 1</span> output
-is connected to the right-hand inlet of <span class="pdobj">f</span>. This <i>cold</i> inlet
-merely stores the value for the next time the <span class="pdobj">f</span> is sent the
+<P>Here, the <b>[f]</b> object is an abbreviation for
+<b>[float]</b>. Note that the <b>[+ 1]</b> output
+is connected to the right-hand inlet of <b>[f]</b>. This <i>cold</i> inlet
+merely stores the value for the next time the <b>[f]</b> is sent the
 "bang" message.
 
 <P>It is frequently desirable to send messages to two or more inlets of an object
-to specify its action. For instance, you can use <span class="pdobj">+</span> to add two numbers; but
-to do it correctly you must make sure the right hand inlet gets its value
-first. Otherwise, when the left hand side value comes in, <span class="pdobj">+</span> will carry out
-the addition (since the left hand inlet is the "hot" one) and will add this
+to specify its action. For instance, you can use <b>[+]</b> to add two
+numbers; but to do it correctly you must make sure the right hand inlet gets its value
+first. Otherwise, when the left hand side value comes in, <b>[+]</b>
+will carry out the addition (since the left hand inlet is the "hot" one) and will add this
 value to whatever was previously sitting in the right hand inlet.
 
 <P>Problems can arise when a single outlet is connected (either directly or
 through arbitrarily long chains of message passing) to different inlets of a
 single object. In this case it is indeterminate which order the two inlets will
-receive their messages. Suppose for example you wish to use <span class="pdobj">+</span> to double a
-number. The following is incorrect:
+receive their messages. Suppose for example you wish to use <b>[+]</b>
+to double a number. The following is incorrect:
 
 <figure>
 <IMG src="img/2.4.6.png" ALT="incorrect inlet connection">
@@ -1035,26 +1055,28 @@ number. The following is incorrect:
 </figure>
 
 <P>Here, the left inlet was connected before connecting the right hand one
-(although this is not evident in the appearance of the patch). The <span class="pdobj">+</span> thus
-adds the new input (at left) to the previous input (at right).
+(although this is not evident in the appearance of the patch). The
+<b>[+]</b> thus adds the new input (at left) to the previous input
+(at right).
 
-<P>The <span class="pdobj">trigger</span> object, abbreviated <span class="pdobj">t</span>, can be used to split out connections
-from a single outlet in a determinate order. By convention, all objects in Pd,
-when sending messages out more than one outlet, do so from right to left. If
-you connect these to inlets of a second object without crossing wires, the
-second object will get its leftmost inlet last, which is usually what you
-want. Here is how to use <span class="pdobj">trigger</span> to disambiguate the previous example:
+<P>The <b>[trigger]</b> object, abbreviated <b>[t]</b>,
+can be used to split out connections from a single outlet in a determinate order.
+By convention, all objects in Pd, when sending messages out more than one outlet,
+do so from right to left. If you connect these to inlets of a second object without
+crossing wires, the second object will get its leftmost inlet last, which is usually
+what you want. Here is how to use <b>[trigger]</b> to disambiguate
+the previous example:
 
 </P><figure>
     <IMG src="img/2.4.7.png" ALT="trigger to disambiguate">
-    <figcaption>A defined connection order with <span class="pdobj">trigger</span></figcaption>
+    <figcaption>A defined connection order with <b>[trigger]</b></figcaption>
 </figure>
 
 <P>"Cold" (non-leftmost) inlets are almost universally used to store single
-values (either numbers or symbols). With the exception of <span class="pdobj">line</span>, <span class="pdobj">line~</span>
-and <span class="pdobj">vline~</span>, these values are "sticky", i.e., once you set the value it is
-good until the next time you set it. (The "line family" exception is for
-sanity's sake.)
+values (either numbers or symbols). With the exception of <b>[line]</b>,
+<b>[line~]</b> and <b>[vline~]</b>, these values are
+"sticky", i.e., once you set the value it is good until the next time you set it. (The
+"line family" exception is for sanity's sake.)
 
 <P>One more question sometimes comes up concerning execution order when two
 messages are sent to a single "cold" inlet. In this situation, since the messages
@@ -1086,9 +1108,10 @@ the selector "my" and the two arguments are the number 5 and the symbol "toes".
 </figure>
 
 <P>Here, the three messages are the numbers 1, 2, and 3, and they are sent in
-sequence (with no intervening time between them, as with the <span class="pdobj">trigger</span> object,
-and having depth-first consequences so that whatever chain of actions depending
-on "1" takes place before anything depending on "2" and so on).
+sequence (with no intervening time between them, as with the
+<b>[trigger]</b> object, and having depth-first consequences so that
+whatever chain of actions depending on "1" takes place before anything depending
+on "2" and so on).
 
 <P>Semicolons may also separate messages. A message following a semicolon must
 specify a symbol giving a destination (in other words, semicolons are like commas
@@ -1166,28 +1189,32 @@ or in the "audio setup" dialog).
 
 <P>Pd can read or write samples to files either in 16-bit or 24-bit fixed point
 or in 32-bit floating point, in 'wave', 'aiff', 'caf', and 'next' formats via
-the <span class="pdobj">soundfiler</span>, <span class="pdobj">readsf~</span>, and <span class="pdobj">writesf~</span> objects.
+the <b>[soundfiler]</b>, <b>[readsf~]</b>,
+and <b>[writesf~]</b> objects.
 
 <H4> <A id="s2.5.2">2.5.2. Tilde objects and audio connections</A> </H4>
 
-<P>Audio computations in Pd are carried out by "tilde objects" such as <span class="pdobj">osc~</span>,
-whose names conventionally end with a tilde character (which resembles a sinusoid,
-symbolizing their function in handling audio signals). Tilde objects can
-intercommunicate via audio connections. When audio computation is turned on or
-when you change the audio network while audio is on, Pd sorts all the tilde objects
-into a linear order for running; this linear list is then by default run down in
-blocks of 64 samples each at 44100 Hz. this means the audio network runs every
-1.45 milliseconds.
+<P>Audio computations in Pd are carried out by "tilde objects" such as
+<b>[osc~]</b>, whose names conventionally end with a tilde character
+(which resembles a sinusoid, symbolizing their function in handling audio signals).
+Tilde objects can intercommunicate via audio connections. When audio computation is
+turned on or when you change the audio network while audio is on, Pd sorts all the
+tilde objects into a linear order for running; this linear list is then by default
+run down in blocks of 64 samples each at 44100 Hz. this means the audio network runs
+every 1.45 milliseconds.
 
 <P>Inlets or outlets are configured in Pd either for messages or audio. You can't
 connect an audio outlet to a non-audio inlet. An object's leftmost inlet may accept
 both audio and messages; any other inlet is either one or the other, but secondary
 audio inlets take floats at control rate and promote them automatically to signals.
 Nonetheless, in some cases, the inlet may take both a float or a sinal and run
-different algorithms in each case. One example is <span class="pdobj">lop~</span>, which runs a more
-efficient routine if no signals are connected to the right inlet. The <span class="pdobj">+~</span>, <span class="pdobj">-~</span>,
-<span class="pdobj">*~</span>, <span class="pdobj">/~</span>. <span class="pdobj">max~</span>, <span class="pdobj">min~</span>, <span class="pdobj">log~</span> and <span class="pdobj">pow~</span> objects can be configured to take
-control or signal inputs in their 2nd inlet depending on the creation argument.
+different algorithms in each case. One example is <b>[lop~]</b>,
+which runs a more efficient routine if no signals are connected to the right inlet.
+The <b>[+~]</b>, <b>[-~]</b>, <b>[*~]</b>,
+<b>[/~]</b>. <b>[max~]</b>, <b>[min~]</b>,
+<b>[log~]</b> and <b>[pow~]</b> objects can be
+configured to take control or signal inputs in their 2nd inlet depending on the
+creation argument.
 
 <P>The audio network, that is, the tilde objects and their interconnections,
 must be non-cyclic. If there are loops at "sort time", you will see an error
@@ -1202,112 +1229,127 @@ objects weren't scheduled)".
 <P> You can build algorithms with feedback using nonlocal signal connections
 as explained in the <A href="x2.htm#s2.5.5">2.5.5. subsection</A>.
 
-<P>Your subpatches can have audio inlets and outlets via the <span class="pdobj">inlet~</span> and <span class="pdobj">outlet~</span>
+<P>Your subpatches can have audio inlets and outlets via the
+<b>[inlet~]</b> and <b>[outlet~]</b>
 objects (see <A href="x2.htm#s2.8">2.8. Subpatches</A>).
 
 <H4> <A id="s2.5.3">2.5.3. Converting audio to and from messages</A> </H4>
 
-<P>If you want to use a control value as a signal, you can use the <span class="pdobj">sig~</span>
+<P>If you want to use a control value as a signal, you can use the <b>[sig~]</b>
 object to convert it. This is usually rare since objects mostly promote
 floats to signals as mentioned. At least this is true for all native objects
-in Pd, but there are externals that can behave differently. The <span class="pdobj">sig~</span> object
-is also useful for loading a default signal value with its creation argument.
-You can also use <span class="pdobj">line~</span> and <span class="pdobj">vline~</span> to "convert" from control to signal with
-a smoothing ramp, which can be quite useful.
+in Pd, but there are externals that can behave differently. The <b>[sig~]</b>
+object is also useful for loading a default signal value with its creation argument.
+You can also use <b>[line~]</b> and <b>[vline~]</b>
+to "convert" from control to signal with a smoothing ramp, which can be quite useful.
 
 <P>The other direction, signal to control, requires that you specify at what
-moments you want the signal sampled. This is handled by the <span class="pdobj">snapshot~</span> object,
-but you can also sample a signal with <span class="pdobj">tabwrite~</span> and then access it via
-<span class="pdobj">tabread</span> or <span class="pdobj">tabread4</span> (note the missing tildes!) There are also analysis
-objects, the simplest of which is <span class="pdobj">env~</span>, the envelope follower, that outputs
-control rate floats.
+moments you want the signal sampled. This is handled by the
+<b>[snapshot~]</b> object, but you can also sample a signal with
+<b>[tabwrite~]</b> and then access it via <b>[tabread]</b>
+or <b>[tabread4]</b> (note the missing tildes!) There are also analysis
+objects, the simplest of which is <b>[env~]</b>, the envelope follower,
+that outputs control rate floats.
 
 <H4> <A id="s2.5.4">2.5.4. Switching and blocking</A> </H4>
 
-<P>You can use the <span class="pdobj">switch~</span> or <span class="pdobj">block~</span> objects to turn portions of your audio
-computation on and off and to control the block size of computation. There may
-be only one <span class="pdobj">switch~</span> or <span class="pdobj">block~</span> object per window; it acts on the entire
+<P>You can use the <b>[switch~]</b> or <b>[block~]</b>
+objects to turn portions of your audio computation on and off and to control the block size
+of computation. There may be only one <b>[switch~]</b> or
+<b>[block~]</b> object per window; it acts on the entire
 window and all of its subwindows (which may still have their own nested
-<span class="pdobj">switch~</span>/<span class="pdobj">block~</span> objects though). Both, <span class="pdobj">switch~</span> and <span class="pdobj">block~</span> take a block
+<b>[switch~]</b>/<b>[block~]</b> objects though). Both,
+<b>[switch~]</b> and <b>[block~]</b> take a block
 size and optional overlap and up-/downsampling factors as arguments; so for
 instance, [block~ 1024 4] specifies 1024 sample blocks, overlapped by a factor
-of 4 relative to the parent window. The <span class="pdobj">switch~</span> version carries a small
-computational overhead in addition to whatever overhead is associated with
+of 4 relative to the parent window. The <b>[switch~]</b> version carries
+a small computational overhead in addition to whatever overhead is associated with
 changing the block size.
 
 <P>Larger block sizes than 64 should result in a small increase of runtime
-efficiency. Also, the <span class="pdobj">fft~</span> and related objects operate on blocks so that
-setting the block size also sets the number of FFT channels. You may wish
+efficiency. Also, the <b>[fft~]</b> and related objects operate on blocks
+so that setting the block size also sets the number of FFT channels. You may wish
 to use block sizes smaller than 64 to gain finer resolutions of message/audio
 interaction, or to reduce "block delay" in feedback algorithms. At the extreme,
 setting the block size to 1 allows you to write your own recursive filters or
 other DSP algorithms that require a 1-sample-feedback.
 
-<P>You can use <span class="pdobj">switch~</span> to budget your DSP computations. For instance you might
-want to be able to switch between two synthesis algorithms. To do this, put
-each algorithm in its own subpatch (which can have sub-subpatches in turn, for
-a voice bank for instance), and switch each one off as you switch the other one
-on. Beware of clicks; if you have a <span class="pdobj">line~</span> controlling output level, give it
-time to ramp to zero before you switch it off or it will be stuck at a non-zero
+<P>You can use <b>[switch~]</b> to budget your DSP computations.
+For instance you might want to be able to switch between two synthesis algorithms.
+To do this, put each algorithm in its own subpatch (which can have sub-subpatches in
+turn, for a voice bank for instance), and switch each one off as you switch the other one
+on. Beware of clicks; if you have a <b>[line~]</b> controlling output
+level, give it time to ramp to zero before you switch it off or it will be stuck at a non-zero
 value for the next time it comes back on.
 
 <P>When a subpatch is switched off, its audio outputs generate zeros, which
-costs a fairly small overhead. A cheaper way to get outputs is to use <span class="pdobj">throw~</span>
-inside the switched module and <span class="pdobj">catch~</span> outside it.
+costs a fairly small overhead. A cheaper way to get outputs is to use
+<b>[throw~]</b> inside the switched module and
+<b>[catch~]</b> outside it.
 
 <H4> <A id="s2.5.5">2.5.5. Nonlocal signal connections</A> </H4>
 
 <P>You may wish to pass signals non-locally, either to get from one window to
 another, or to feed a signal back to your algorithm's input. This can be done
-using <span class="pdobj">throw~</span>/<span class="pdobj">catch~</span>, <span class="pdobj">send~</span>/<span class="pdobj">receive~</span>, or <span class="pdobj">delwrite~</span>/<span class="pdobj">delread~</span> or
-<span class="pdobj">delread4~</span> pairs. Both, <span class="pdobj">throw~</span> and <span class="pdobj">catch~</span> implement a summing bus; <span class="pdobj">throw~</span>
-adds into the bus and <span class="pdobj">catch~</span> reads out the accumulated signal and zeros the
-bus for the next time around. There can be many <span class="pdobj">throw~</span> objects associated with
-a single <span class="pdobj">catch~</span>, but a <span class="pdobj">throw~</span> can't talk to more than one <span class="pdobj">catch~</span>. You can
-reset the destination of a <span class="pdobj">throw~</span> if you want to.
+using <b>[throw~]</b>/<b>[catch~]</b>,
+<b>[send~]</b>/<b>[receive~]</b>, or
+<b>[delwrite~]</b>/<b>[delread~]</b> or
+<b>[delread4~]</b> pairs. Both, <b>[throw~]</b>
+and <b>[catch~]</b> implement a summing bus; <b>[throw~]</b>
+adds into the bus and <b>[catch~]</b> reads out the accumulated signal and
+zeros the bus for the next time around. There can be many <b>[throw~]</b>
+objects associated with a single <b>[catch~]</b>, but a
+<b>[throw~]</b> can't talk to more than one <b>[catch~]</b>.
+You can reset the destination of a <b>[throw~]</b> if you want to.
 
-<P>On the other hand, <span class="pdobj">send~</span> just saves a signal which may then be received
-by a <span class="pdobj">receive~</span> object any number of times; but a <span class="pdobj">receive~</span> can only pick up
-one <span class="pdobj">send~</span> at a time (you can switch between <span class="pdobj">send~</span> objects if you want though).
+<P>On the other hand, <b>[send~]</b> just saves a signal which may then
+be received by a <b>[receive~]</b> object any number of times; but a
+<b>[receive~]</b> can only pick up one <b>[send~]</b> at
+a time (you can switch between <b>[send~]</b> objects if you want though).
 
-<P>Don't try to <span class="pdobj">throw~</span> and <span class="pdobj">catch~</span> or <span class="pdobj">send~</span> and <span class="pdobj">receive~</span> between windows
+<P>Don't try to <b>[throw~]</b> and <b>[catch~]</b>
+or <b>[send~]</b> and <b>[receive~]</b> between windows
 with different block sizes. The only well tested re-blocking mechanisms are
-<span class="pdobj">inlet~</span> and <span class="pdobj">outlet~</span>.
+<b>[inlet~]</b> and <b>[outlet~]</b>.
 
 <P>When you send a signal to a point that is earlier in the sorted list of
 tilde objects, the signal doesn't get there until the next cycle of DSP
 computation (one block later), so your signal will be delayed by one block
-(1.45 msec by default). The <span class="pdobj">delwrite~</span> and <span class="pdobj">delread~</span>/<span class="pdobj">delread4~</span> have this
+(1.45 msec by default). The <b>[delwrite~]</b> and
+<b>[delread~]</b>/<b>[delread4~]</b> have this
 same restriction, but here, the 1.45 msec are minimum attainable delay.
 
 <H4> <A id="s2.5.6">2.5.6. Multichannel signals</A> </H4>
 
 <P>As of Pd version 0.54-0, signals may be multichannel. Every signal has a
 <i>length</i> equal to the window's block size (64 by default), and also has a
-<i>channel count</i> which is 1 by default. The <span class="pdobj">snake~</span> object can combine
-any number of single-channel signals into a multichannel one, or alternatively
-can split a multichannel signal into its component single-channel ones.
-Non-local connections (<span class="pdobj">send~</span>, <span class="pdobj">receive~</span>, <span class="pdobj">throw~</span>, <span class="pdobj">catch~</span>, <span class="pdobj">inlet~</span> and
-<span class="pdobj">outlet~</span>) can be used to pass multichannel signals from window to window, and
-<span class="pdobj">dac~</span> and <span class="pdobj">adc~</span> can input and output several inputs or outputs into, or out of
+<i>channel count</i> which is 1 by default. The <b>[snake~]</b> object
+can combine any number of single-channel signals into a multichannel one, or alternatively
+can split a multichannel signal into its component single-channel ones. Non-local connections
+(<b>[send~]</b>, <b>[receive~]</b>,
+<b>[throw~]</b>, <b>[catch~]</b>,
+<b>[inlet~]</b> and <b>[outlet~]</b>) can be used to
+pass multichannel signals from window to window, and <b>[dac~]</b> and
+<b>[adc~]</b> can input and output several inputs or outputs into, or out of
 one multichannel signal.
 
-<P>The <span class="pdobj">receive~</span>, <span class="pdobj">catch~</span>, and <span class="pdobj">adc~</span> objects take arguments to specify the
+<P>The <b>[receive~]</b>, <b>[catch~]</b>, and
+<b>[adc~]</b> objects take arguments to specify the
 desired number of channels.
 
 <P>Stateless objects, which have no memory from one DSP tick to the next, have
 all been adapted to handle multichannel inputs and outputs. The arithmetic and
-math objects (<span class="pdobj">+~</span>, <span class="pdobj">-~</span>, <span class="pdobj">*~</span>, <span class="pdobj">/~</span>, <span class="pdobj">wrap~</span>, <span class="pdobj">sqrt~</span> and so on) use their
-inputs to determine their channel counts. Binary operations like <span class="pdobj">+~</span> can combine
-single- and multichannel inputs.
+math objects (<b>[+~]</b>, <b>[-~]</b>,
+<b>[*~]</b>, <b>[/~]</b>, <b>[wrap~]</b>,
+<b>[sqrt~]</b> and so on) use their inputs to determine their channel counts.
+Binary operations like <b>[+~]</b> can combine single- and multichannel inputs.
 
 <P>Other objects, such as filters or oscillators, have not been adapted for
 multichannel signals, because there might be many ways to design multichannel
-versions of them. Instead, you can use the <span class="pdobj">clone</span> object to perform general
-operations on multichannel signals. Signal inputs and outputs of cloned patches
-can be used to distribute multichannel signals among the individual cloned
+versions of them. Instead, you can use the <b>[clone]</b> object to
+perform general operations on multichannel signals. Signal inputs and outputs of cloned
+patches can be used to distribute multichannel signals among the individual cloned
 patches.
-
 
 <H3> <A id="s2.6">2.6. Scheduling</A> </H3>
 
@@ -1364,11 +1406,11 @@ close them when you aren't using them.
 
 <H4> <A id="s2.6.3">2.6.3. Determinism</A> </H4>
 
-<P>All message cascades that are scheduled (via <span class="pdobj">delay</span> and its relatives) to
-happen before a given audio tick will happen as scheduled, regardless of whether
-Pd as a whole is running on time; in other words, calculation is never reordered
-for any real-time considerations. This is done in order to make Pd's operation
-deterministic.
+<P>All message cascades that are scheduled (via <b>[delay]</b>
+and its relatives) to happen before a given audio tick will happen as scheduled,
+regardless of whether Pd as a whole is running on time; in other words, calculation
+is never reordered for any real-time considerations. This is done in order to make Pd's
+operation deterministic.
 
 <P>If a message cascade is started by an external event, a time tag is given
 to it. These time tags are guaranteed to be consistent with the times at which
@@ -1376,13 +1418,13 @@ timeouts are scheduled and DSP ticks are computed; i.e., time never decreases.
 (However, either Pd or a hardware driver may lie about the physical time an
 input arrives; this depends on the operating system.) "Timer" objects which
 measure time intervals, measure them in terms of the logical time stamps of the
-message cascades, so that timing a <span class="pdobj">delay</span> object always gives exactly the
-theoretical value. (There is, however, a <span class="pdobj">realtime</span> object that measures real
+message cascades, so that timing a <b>[delay]</b> object always
+gives exactly the theoretical value. (There is, however, a
+<b>[realtime]</b> object that measures real
 time, with nondeterministic results.)
 
 <P>If two message cascades are scheduled for the same logical time, they are
 carried out in the order they were scheduled.
-
 
 <H3> <A id="s2.7">2.7. Semantics</A> </H3>
 
@@ -1406,9 +1448,9 @@ message is used to create the new one.
 <P>The selector of the message (the first word in the message) is a selector
 which Pd interprets to determine the type of object to create. Any message
 arguments (called "creation arguments") are used to parametrize the object
-being created. Thus, in <span class="pdobj">makenote 64 250</span> the selector "makenote" determines
-the class of object to create and the creation arguments "64" and "250" become
-the initial velocity and duration.
+being created. Thus, in <b>[makenote 64 250]</b> the selector
+"makenote" determines the class of object to create and the creation arguments "64"
+and "250" become the initial velocity and duration.
 
 <H4> <A id="s2.7.2">2.7.2. Persistence of data</A> </H4>
 
@@ -1428,9 +1470,9 @@ typing "pd jane" instead of "pd spot", the contents of the patch are preserved
 and only the text in the object box and the window title of the subpatch are
 changed.
 
-<P>It is probably bad style to specify creation arguments ala <span class="pdobj">makenote 64 250</span>
-if you are going to override them later; this is confusing to anyone who tries
-to understand the patch.
+<P>It is probably bad style to specify creation arguments ala
+<b>[makenote 64 250]</b> if you are going to override them later;
+this is confusing to anyone who tries to understand the patch.
 
 <H4> <A id="s2.7.3">2.7.3. Message passing</A> </H4>
 
@@ -1447,16 +1489,17 @@ determined by the selector of the creation message, i.e., the first atom of the
 creation message which is usually a symbol.
 
 <P>Each class comes with a fixed collection of messages it may be sent. For
-example, the <span class="pdobj">float</span> or <span class="pdobj">f</span> object takes "bang" and "float". These messages
-are sent to <span class="pdobj">float</span> objects (objects whose class is float) via the leftmost,
+example, the <b>[float]</b> or <b>[f]</b>
+object takes "bang" and "float". These messages are sent to <b>[float]</b>
+objects (objects whose class is float) via the leftmost,
 hot inlet (the right inlet is a separate, auxiliary object). Objects of
 class "float" respond to the message "bang" by outputting their current value,
 that is, by sending a "float" message to their outlet. They respond to "float"
 messages by setting their value and then outputting it.
 
-<P>Each other class (like <span class="pdobj">float</span>) in Pd has its own protocol for responding
-to messages it is sent, and may take "float" and "bang" messages, or others
-in addition or instead of them.
+<P>Each other class (like <b>[float]</b>) in Pd has its
+own protocol for responding to messages it is sent, and may take "float" and "bang"
+messages, or others in addition or instead of them.
 
 <H4> <A id="s2.7.4">2.7.4. Inlets and lists</A> </H4>
 
@@ -1507,12 +1550,12 @@ example, have an abstraction "a1" that invokes an abstraction "a2" twice, as
 "a1 cat" and "a1 dog". Inside the four "a2" copies, $1 will evaluate to
 "dog-food", "cat-food", "dog-ears", and "cat-ears".
 
-
 <H3> <A id="s2.8">2.8. Subpatches</A> </H3>
 
 <p>Pd offers two mechanisms for making subpatches, called "one-off subpatches"
 and "abstractions". In either case the subpatch appears as an object box
-in a patch. If you type <span class="pdobj">pd</span> or <span class="pdobj">pd my-name</span> into an object box, this creates
+in a patch. If you type <b>[pd]</b> or
+<b>[pd my-name]</b> into an object box, this creates
 a one-off subpatch. For instance, in this fragment:
 
 <figure>
@@ -1531,11 +1574,13 @@ a one-off subpatch. For instance, in this fragment:
 one file. If you make several copies of a subpatch you may change them
 individually.
 
-<P>The objects <span class="pdobj">inlet</span>, <span class="pdobj">inlet~</span>, <span class="pdobj">outlet</span> and <span class="pdobj">outlet~</span>, when put in a
+<P>The objects <b>[inlet]</b>, <b>[inlet~]</b>,
+<b>[outlet]</b> and <b>[outlet~]</b>, when put in a
 subpatch, create inlets and outlets for the object box containing the subpatch.
 This works equally for one-off subpatches and abstractions and only accept
-control data messages. The <span class="pdobj">inlet~</span> and <span class="pdobj">outlet~</span> versions create inlets and
-outlets for audio signals. Note you can also mix control messages in an <span class="pdobj">inlet~</span>
+control data messages. The <b>[inlet~]</b> and
+<b>[outlet~]</b> versions create inlets and outlets for audio signals.
+Note you can also mix control messages in an <b>[inlet~]</b>
 via its right outlet, but a signal outlet only takes signals. Inlets and outlets
 appear on the invoking box in the same left-to-right order as they appear in the
 subpatch.
@@ -1543,7 +1588,7 @@ subpatch.
 <H4> <A id="s2.8.1">2.8.1. Abstractions</A> </H4>
 
 <P>To make an abstraction, save a patch with a name such as "abstraction1.pd"
-and then invoke it in an object box as <span class="pdobj">abstraction1</span>:
+and then invoke it in an object box as <b>[abstraction1]</b>:
 
 <figure>
     <IMG src="img/2.8.3.png" ALT="abstraction">
@@ -1555,18 +1600,18 @@ patch shown here:
 
 <figure>
     <IMG src="img/2.8.4.png" ALT="abstraction example">
-    <figcaption>The insides of the <span class="pdobj">abstraction1</span> abstraction</figcaption>
+    <figcaption>The insides of the <b>[abstraction1]</b> abstraction</figcaption>
 </figure>
 
-<p>You may create many instances of <span class="pdobj">abstraction1</span> or invoke it from different
-patches. Changing and saving the contents of <span class="pdobj">abstraction1</span> will affect all
+<p>You may create many instances of <b>[abstraction1]</b> or invoke it from different
+patches. Changing and saving the contents of <b>[abstraction1]</b> will affect all
 invocations of it as they are created. An analogy from the "c" programming
 language is that one-off subpatches are like bracketed blocks of code and
 abstractions are like subroutines.
 
 <P>Abstractions are instantiated by typing the name of a patch (minus the ".pd"
 extension) into an object box. You may also type arguments; for instance if
-you have a file "my-abstraction.pd" you may have <span class="pdobj">my-abstraction 5</span> to set the
+you have a file "my-abstraction.pd" you may have <b>[my-abstraction 5]</b> to set the
 variable "$1" to 5. This is defined only for object boxes (not for messages) in
 the abstraction. For message boxes, "$1", etc, have a different meaning as
 described above, so note that dollar signs are expanded at a different time in
@@ -1576,12 +1621,12 @@ to send a message with a "$1" in the sense of a creation argument of an
 abstraction, you must generate it with an object box such as [float $1],
 [symbol $1], or perhaps [pack $1 $2], which may then be sent to a message box.
 
-<P> The <span class="pdobj">pdcontrol</span> object has an alternative strategy for retrieving arguments
+<P> The <b>[pdcontrol]</b> object has an alternative strategy for retrieving arguments
 in an abstraction with the 'args' message, which makes the object output a list
 with all argument values. This has the advantage of being able to get a variable
 number of arguments, as well as varying their atom type.
 
-<P>A <span class="pdobj">clone</span> object is provided to automatically create and manage multiple copies
+<P>A <b>[clone]</b> object is provided to automatically create and manage multiple copies
 of an abstraction. You can use it to make voice banks for polyphonic synthesis,
 for example.
 
@@ -1589,7 +1634,7 @@ for example.
 
 <p>If you open the "properties" dialog for a subpatch or an abstraction, you can
 check the "graph on parent" box to have the controls of the subpatch/abstraction
-appear on the parent. For instance, here is an invocation of <span class="pdobj">abstraction2</span>:
+appear on the parent. For instance, here is an invocation of <b>[abstraction2]</b>:
 
 <figure>
     <IMG src="img/2.8.5.png" ALT="graph-on-parent abstraction">
@@ -1659,16 +1704,16 @@ You can use objects to read and write arrays and manipulate them in many ways.
 
 <figure>
     <IMG src="img/2.9.2.png" ALT="array indexing">
-    <figcaption>Read an array with <span class="pdobj">tabread</span></figcaption>
+    <figcaption>Read an array with <b>[tabread]</b></figcaption>
 </figure>
 
 
 <p>Here, we see that the third point of the array (index 2) has the value '0.385'.
-To write into the array, you can use the <span class="pdobj">tabwrite</span> object:
+To write into the array, you can use the <b>[tabwrite]</b> object:
 
 <figure>
     <IMG src="img/2.9.3.png" ALT="setting an value in an array">
-    <figcaption>Write to an array with <span class="pdobj">tabwrite</span></figcaption>
+    <figcaption>Write to an array with <b>[tabwrite]</b></figcaption>
 </figure>
 
 
@@ -1681,16 +1726,16 @@ the patch below creates a 440 Hz tone with "array1" as a waveform:
 
 <figure>
     <IMG src="img/2.9.4.png" ALT="setting an array with a waveform">
-    <figcaption>Using signals to read an with <span class="pdobj">tabread4~</span></figcaption>
+    <figcaption>Using signals to read an with <b>[tabread4~]</b></figcaption>
 </figure>
 
-<p>Here, <span class="pdobj">phasor~</span> outputs a ramp whose output range is from 0 to 1, repeating
+<p>Here, <b>[phasor~]</b> outputs a ramp whose output range is from 0 to 1, repeating
 440 times per second. The multiplier and adder adjust the range from 1 to 11
-and then the values are used as indices for <span class="pdobj">tabread4~</span>, which is a 4-point
+and then the values are used as indices for <b>[tabread4~]</b>, which is a 4-point
 interpolating table lookup module. (Much more detail is available in the
 "3.audio.examples" series in the documentation folder.)
 
-<P>To create a new array, select "array" from the <span class="pdobj">Put menu</span>. A dialog
+<P>To create a new array, select "array" from the <b>Put menu</b>. A dialog
 will appear to set initial properties of the array. By default, a new graph is
 created to hold the array, but it may also be housed in the most recently
 created graph instead. Other properties may be specified there and/or changed
@@ -1734,7 +1779,6 @@ in pixels.
 
 <P>Many other operations are defined for arrays; see the related patches
 in the tutorial (starting at 2.control/15.array.pd) for more possibilities.
-
 
 <H3> <A id="s2.10">2.10. Data structures</A> </H3>
 
@@ -1797,9 +1841,10 @@ above.
     <figcaption>The "struct" and drawing instructions for the score's elements</figcaption>
 </figure>
 
-<p>Templates consist of a data structure definition (the <span class="pdobj">struct</span> object) and
-zero or more drawing instructions (such as <span class="pdobj">filledpolygon</span> and <span class="pdobj">plot</span>). The
-<span class="pdobj">struct</span> object gives the template the name "template-event". The data structure
+<p>Templates consist of a data structure definition (the <b>[struct]</b>
+object) and zero or more drawing instructions (such as <b>[filledpolygon]</b>
+and <b>[plot]</b>). The <b>[struct]</b> object gives
+the template the name "template-event". The data structure
 is defined to contain three floating point numbers named "x", "y", and "color",
 and two arrays, one named "pitch" whose elements belong to another template
 named "template-pitch", and similarly for the array "amp" (both data structures
@@ -1809,23 +1854,25 @@ and width.)
 <P>In general, data structures are built from four data types: scalar floats
 and symbols, text and arrays (whose elements share another, specified template).
 The contents of a Pd window themselves form a list. An array (Pd's correlate of
-Max's <span class="pdobj">table</span> object) is implemented as a top-level data structure array whose
-elements are scalars containing a single floating-point number.
+Max's <b>[table]</b> object) is implemented as a top-level data
+structure array whose elements are scalars containing a single floating-point number.
 
 <P>Data structures in Pd may nest arbitrarily deeply using the array and text
 types. For example, a collection of sinusoidal tracks from an analysis engine
 could be implemented as an array of arrays of (pitch, amplitude) pairs.
 
-<P>After the <span class="pdobj">struct</span> object in the template shown above, the remaining three
-objects are <I>drawing instructions</I>, first for a rectangle (with the
-<span class="pdobj">filledpolygon</span> object), and then for two arrays (with the <span class="pdobj">plot</span> objects).
-The various graphical attributes that are specified for drawing instructions
+<P>After the <b>[struct]</b> object in the template shown above,
+the remaining three objects are <I>drawing instructions</I>, first for a rectangle (with the
+<b>[filledpolygon]</b> object), and then for two arrays (with the
+<b>[plot]</b> objects). The various graphical attributes that are
+specified for drawing instructions
 may be numerical constants or data structure field names; in the latter case
 the value varies depending on the data. For instance, the second creation
-argument to <span class="pdobj">plot</span> is the color. The first one plots "pitch" using the color
-"color". In this way the color is attached to the "color" slot in the data
-structure, so that color will vary according to its "color" slot. The second
-<span class="pdobj">plot</span> plots the "amp" field and the color is given as 0, which is black.
+argument to <b>[plot]</b> is the color. The first one plots
+"pitch" using the color "color". In this way the color is attached to the "color"
+slot in the data structure, so that color will vary according to its "color" slot.
+The second <b>[plot]</b> plots the "amp" field and the color is
+given as 0, which is black.
 
 <H4> <A id="s2.10.1">2.10.1. Traversal</A> </H4>
 
@@ -1842,7 +1889,8 @@ events, score following, self-modifying scores, reactive improvisation, and
 perhaps much more.
 
 <P> Here is a patch showing how to implement the graphical sequence score shown
-above. It uses the <span class="pdobj">clone</span> object to instantiate different copies of the <span class="pdobj">voice</span>
+above. It uses the <b>[clone]</b> object to instantiate different
+copies of the <b>[voice]</b>
 abstraction, which is responsible for playing back each voice from the score.
 
 <figure>
@@ -1853,21 +1901,24 @@ abstraction, which is responsible for playing back each voice from the score.
 <P>Traversal of data is made possible by adding a new type of atom, "pointer",
 to the two previously defined types that make up messages (numbers and symbols).
 Unlike numbers and symbols, pointers have no printed form and thus can't be
-uttered in message boxes. Traversal objects such as <span class="pdobj">pointer</span> and <span class="pdobj">get</span>(among
+uttered in message boxes. Traversal objects such as <b>[pointer]</b>
+and <b>[get]</b>(among
 several others) can generate or use pointers. The pointer data type is also
-integrated into pipe-fitting objects such as <span class="pdobj">pack</span>, <span class="pdobj">unpack</span>, and <span class="pdobj">route</span>.
-The <span class="pdobj">trigger</span> object also deals with pointers.
+integrated into pipe-fitting objects such as <b>[pack]</b>,
+<b>[unpack]</b>, and <b>[route]</b>.
+The <b>[trigger]</b> object also deals with pointers.
 
-<P>In the patch shown above, the <span class="pdobj">pointer</span> object holds a pointer to the next
-object to "play" (by sending it to a copy of the <span class="pdobj">voice</span> abstractions). The
+<P>In the patch shown above, the <b>[pointer]</b> object holds
+a pointer to the next object to "play" (by sending it to a copy of the
+<b>[voice]</b> abstractions). The
 pointer object takes a "traverse" message to set it to the head of the list
 (named "pd-data"), and "next" messages to move to (and output) the next datum
 in the list (i.e., the next in the list of six objects in the score). Let's
-check the <span class="pdobj">voice</span> abstraction below.
+check the <b>[voice]</b> abstraction below.
 
 <figure>
     <IMG src="img/2.10.4.png" ALT="[voice] abstraction">
-    <figcaption>The cloned [voice] abstraction with sound synthesis</figcaption>
+    <figcaption>The cloned <b>[voice]</b> abstraction with sound synthesis</figcaption>
 </figure>
 
 <P>The [pd sequence] subpatch takes care of sequencing the data structure
@@ -1878,8 +1929,8 @@ events.
     <figcaption>The sequencing subpatch</figcaption>
 </figure>
 
-<P>A second <span class="pdobj">pointer</span> object is used here as a storage cell for pointers just
-as <span class="pdobj">float</span> is for numbers. The center of the sequencer is the <span class="pdobj">delay</span> object,
+<P>A second <b>[pointer]</b> object is used here as a storage cell for pointers just
+as <b>[float]</b> is for numbers. The center of the sequencer is the <b>[delay]</b> object,
 which must be fed the time difference between each event (including the
 non-event of hitting "start") and the next. As we extract each of the six
 objects in the score, we must wait the delay for playing that object, and
@@ -1887,19 +1938,19 @@ then send its pointer to other abstractions that read data from the 'pitch'
 and 'amp' arrays. However, we have to inspect the object itself to know the
 delay before playing it. So, in the loop, we peel off the first remaining
 object to play and inspect the time difference between it and the previous
-one, using this value to set the <span class="pdobj">delay</span> object.
+one, using this value to set the <b>[delay]</b> object.
 
-<P>The time difference needed to set the <span class="pdobj">delay</span> object is obtained using the
-<span class="pdobj">get template-event</span> object with the 'x' field. This is converted to incremental
-time with <span class="pdobj">-</span>, corrected for tempo, and fed to the <span class="pdobj">delay</span> object. Pd provides
-the <span class="pdobj">get</span> and <span class="pdobj">set</span> objects for reading and writing values from data structures.
-The <span class="pdobj">get</span> object shown here obtains the "x" and "y" fields of the current object.
-The template name (template-event) is supplied to the <span class="pdobj">get</span> objects so that
+<P>The time difference needed to set the <b>[delay]</b> object is obtained using the
+<b>[get template-event]</b> object with the 'x' field. This is converted to incremental
+time with <b>[-]</b>, corrected for tempo, and fed to the <b>[delay]</b> object. Pd provides
+the <b>[get]</b> and <b>[set]</b> objects for reading and writing values from data structures.
+The <b>[get]</b> object shown here obtains the "x" and "y" fields of the current object.
+The template name (template-event) is supplied to the <b>[get]</b> objects so that
 they can look up the offset of the necessary field(s) in advance, for greater
 run-time efficiency.
 
 <P>Once the delay time has expired, the object's pointer is recalled with the
-<span class="pdobj">pointer</span> object and sent to the <span class="pdobj">data-array</span> abstraction, which extracts the
+<b>[pointer]</b> object and sent to the <b>[data-array]</b> abstraction, which extracts the
 pitch and dynamic breakpoints from the arrays (specified as the abstraction's
 argument,) so it contains two sequencers itself. The nesting of the overall
 structure of the sequencer patch mirrors the nesting of the original data
@@ -1907,7 +1958,7 @@ structures.
 
 <figure>
     <IMG src="img/2.10.6.png" ALT="[data-array] abstraction">
-    <figcaption>The <span class="pdobj">data-array</span> abstraction</figcaption>
+    <figcaption>The <b>[data-array]</b> abstraction</figcaption>
 </figure>
 
 <P>More general patches can easily be constructed which access heterogeneous
@@ -1917,21 +1968,21 @@ rich personal "score language" can be developed and sequenced.
 <H4> <A id="s2.10.2">2.10.2. Accessing and changing data</A> </H4>
 
 <P>In general, accessing or changing data is done via "pointers" to "scalars".
-Numbers and symbols within scalars are accessed using the <span class="pdobj">get</span> object and
-changed, in the same way, using <span class="pdobj">set</span>. Since lists and arrays are composed of
+Numbers and symbols within scalars are accessed using the <b>[get]</b> object and
+changed, in the same way, using <b>[set]</b>. Since lists and arrays are composed of
 scalars, every actual number or symbol in a data heap will be a number or symbol
 element of some scalar. To access them, it suffices to have objects to chase
 down elements of lists and arrays (given either a global name or a pointer to
 the containing scalar).
 
 <P>Lists are traversed in the way shown above; to get to a sublist of a scalar,
-the <span class="pdobj">get</span> object will provide a pointer, in the same way as it provides "float"
-or "symbol" elements of scalars. For arrays, an <span class="pdobj">element</span> object is provided
+the <b>[get]</b> object will provide a pointer, in the same way as it provides "float"
+or "symbol" elements of scalars. For arrays, an <b>[element]</b> object is provided
 which, given a scalar, a field name and a number, chases down the numbered,
 scalar, element of the named array field.
 
 <P>To alter "float" or "symbol" elements of scalars is straightforward
-using the <span class="pdobj">set</span> object, but arrays and lists can't be set by assignment;
+using the <b>[set]</b> object, but arrays and lists can't be set by assignment;
 there is no suitable data type available within messages. Lists could
 possibly be "settable" by passing pointers to other lists, but permitting this
 would have required either automatically doing deep copies of data structures
@@ -1942,8 +1993,8 @@ scalar is considered as belonging to that scalar, and is left in memory until
 the scalar is deleted; the data may be changed atom by atom, but primitives
 are not provided which would imply unpredictable execution times.
 
-<P>The <span class="pdobj">getsize</span> and <span class="pdobj">setsize</span> objects are provided to access or change
-the number of elements in the array. For lists, an <span class="pdobj">append</span> object
+<P>The <b>[getsize]</b> and <b>[setsize]</b> objects are provided to access or change
+the number of elements in the array. For lists, an <b>[append]</b> object
 appends a new scalar for a given template to a list, after the element pointed
 to. (To insert a scalar at the beginning of a list, the pointer can be set to
 the "head" of the list, a formal location before the first list item.)
@@ -1970,20 +2021,20 @@ dimension; if the dimension is constant, it can't be altered by dragging.
 <P>Tricky situations can arise when the user changes the contents of templates.
 A change in drawing instructions can be accommodated by simply tracking
 down and redrawing all data objects using the template. However, changing
-the <span class="pdobj">struct</span> object itself make for less straightforward situations. The
+the <b>[struct]</b> object itself make for less straightforward situations. The
 user might wish to reorder fields, delete them, add new ones, or rename them.
-When a <span class="pdobj">struct</span> object changes, Pd automatically conforms the data from the old
+When a <b>[struct]</b> object changes, Pd automatically conforms the data from the old
 structure to the new one. Fields with the same name as previously are maintained
 (reordering them as necessary) and if a field disappears but another of the
 same type appears, the new one(s) are taken to be renamings of the old one(s)
 in order of appearance. New fields which cannot be matched in this way with
 previously existing ones are assumed to be new and are initialized.
 
-<P>It can happen that two <span class="pdobj">struct</span> objects compete to define the same data
+<P>It can happen that two <b>[struct]</b> objects compete to define the same data
 structure, or that the user reads in data from a file which expects a different
-version of the structure, or alternatively, that the <span class="pdobj">struct</span> object for
+version of the structure, or alternatively, that the <b>[struct]</b> object for
 existing data objects disappears. For this reason, Pd maintains a private
-representation of the last active version of a <span class="pdobj">struct</span> until all
+representation of the last active version of a <b>[struct]</b> until all
 similarly named "structs", as well as all data using that "struct", have
 disappeared. If the user introduces a new version of the "struct" and only
 later deletes the "current" one, the data is only conformed to the new version
@@ -2007,8 +2058,8 @@ that the user can bind actions to mouse clicks.
 adequate to support a variety of modes of data collection and use, such as
 analysis and sequencing. But the patches required to traverse the data
 collections are not always simple. It would be desirable to find a more
-straightforward mechanism than that provided by the <span class="pdobj">pointer</span>, <span class="pdobj">get</span>
-and <span class="pdobj">set</span> objects.
+straightforward mechanism than that provided by the <b>[pointer]</b>, <b>[get]</b>
+and <b>[set]</b> objects.
 
 <P>The "data" facility, although part of the original plan for Pd, has only
 recently been implemented in its current form, and as (hopefully) the user base
@@ -2058,7 +2109,7 @@ precision version of Pd (Pd64), this is not a significant issue.
 corresponding messages are always sent in right-to-left screen order. In
 Pd, the messages are sent in the order you made the connections in. In either
 case, in situations where you care about the order, it's appropriate to use
-a <span class="pdobj">trigger</span> object to specify.
+a <b>[trigger]</b> object to specify.
 
 <P> In Pd you can edit instances of abstractions and save the result back
 to the file of the abstraction. This isn't possible in MAX, because the
@@ -2068,9 +2119,9 @@ as "$1", etc, and are translated at a slightly later stage of the instance
 process so that you still see them as "$" variables in the instance.
 see <A href="x2.htm#s2.8.1">2.8.1. Abstractions</A>.
 
-<P> In Pd, to make current all instances of the abstraction, either delete
+<!-- <P> In Pd, to update all instances of the abstraction, either delete
 and recreate them or close and open the patch; this is done automatically in MAX.
-
+ -->
 <P> In Pd, if you select "save" while in a subpatch, the parent is saved. In
 MAX, if you do this a dialogue box comes up asking if you want to save the
 subpatch as a separate file (if you want to save a subpatch to a file in Pd,
@@ -2079,7 +2130,7 @@ you have to copy and paste the contents to a new document).
 <P> In Pd, inlets and outlets are ordinary text objects; in MAX they're
 "gui" objects from the palette.
 
-<P> In Pd, there's no <span class="pdobj">gate</span>; instead there's a <span class="pdobj">spigot</span> with the inlets in
+<P> In Pd, there's no <b>[gate]</b>; instead there's a <b>[spigot]</b> with the inlets in
 the opposite, more natural order.
 
 <P> Switching subsets of the DSP patch on and off is done in completely
@@ -2096,14 +2147,14 @@ any commonality between the two.
 <P> The "bpatcher" feature in MAX has a correlate, "graph on parent" subpatches,
 in Pd; however, Pd's version is quite different from MAX's.
 
-<P>  In Pd, there's no <span class="pdobj">preset</span> object (I now think it's basically a bad idea)
+<P>  In Pd, there's no <b>[preset]</b> object (I now think it's basically a bad idea)
 and you have to use explicit sends and receives to restore values to number
 boxes. Then just make a "message" box to re-send the values you want.
 
-<P> In MAX, instead of getting <span class="pdobj">tabosc4~</span> and arrays, you get <span class="pdobj">cycle~</span>
-and <span class="pdobj">buffer~</span>. The only gotcha is that you probably can't draw in <span class="pdobj">buffer~</span>
+<P> In MAX, instead of getting <b>[tabosc4~]</b> and arrays, you get <b>[cycle~]</b>
+and <b>[buffer~]</b>. The only gotcha is that you probably can't draw in <b>[buffer~]</b>
 with the mouse as you can with arrays, but at least it's possible to
-make a patch that copies a "table" into a <span class="pdobj">buffer~</span> object.
+make a patch that copies a "table" into a <b>[buffer~]</b> object.
 
 </div>
 <div id="footer">

--- a/doc/1.manual/x3.htm
+++ b/doc/1.manual/x3.htm
@@ -337,11 +337,13 @@ Pd's Audio settings.
 <p> There's also a MIDI settings dialog for you to configure one or more MIDI
 input and output devices. If more than one device is chosen for either input and
 output, they are registered in different MIDI ports. The "channel message" midi
-objects in Pd (such as [notein] or [pgmout]) will take channels 1-16. Note,
-however, that the MIDI port is encoded in the channel number, where channels 1-16
-mean the first open MIDI port, 17-32 the second one, and so on. The [midiin],
-[midirealtimein] and [sysexin] objects output the port number in their right
-outlet and [midiout] has a separate inlet to specify which MIDI port you want.
+objects in Pd (such as <b>[notein]</b> or
+<b>[pgmout]</b>) will take channels 1-16. Note, however, that the MIDI
+port is encoded in the channel number, where channels 1-16 mean the first open MIDI port,
+17-32 the second one, and so on. The <b>[midiin]</b>,
+<b>[midirealtimein]</b> and <b>[sysexin]</b>
+objects output the port number in their right outlet and <b>[midiout]</b>
+has a separate inlet to specify which MIDI port you want.
 
 <figure>
     <IMG src="img/3.3.4.png" ALT="MIDI settings">
@@ -372,7 +374,7 @@ that you can get choices for API this way.
 
 <P>The "Path" tabs configures search paths that Pd will use to load externals
 and abstractions (spaces in the path are allowed by the way). This also used
-for files in objects that load them like [soundfiler], [text] and even arrays
+for files in objects that load them like <b>[soundfiler]</b>, <b>[text]</b> and even arrays
 (aka tables). The path must be correctly set before you load a patch or it may
 fail to find anything. Filenames in Pd are always separated byc(Unix-style)
 forward slashes, even if you're on Windows (which uses backslashes). Also, note
@@ -382,7 +384,7 @@ that objects that can load files do expand "~" to your home directory.
 directory and, if it fails, it searches next in the paths that are set in this
 tab. Note you can use things like "../samples" to point to folders and subfolders
 that are relative to the patch directory and other search paths. Note you can also
-use [declare] to add paths for particular patches - this and other details about
+use <b>[declare]</b> to add paths for particular patches - this and other details about
 path management is also covered in depth in <a href="x4.htm">Chapter 4: Externals</a>,
 and summarized in <a href="x4.htm#s4.6">4.6. Search order in Pd for objects and files</a>.
 

--- a/doc/1.manual/x4.htm
+++ b/doc/1.manual/x4.htm
@@ -320,7 +320,7 @@ extensions according to each case. See details in the table below:
 <p>You can have a Pd patch behave like an object by loading it into other
 patches - these are usually called “abstractions” (see
 <A href="x2.htm#s2.8.1">2.8.1. Abstractions</A>). Note that some of the
-externals in “extra” are abstractions (for instance, [rev1~] or [hilbert~]).
+externals in “extra” are abstractions (for instance, <b>[rev1~]</b> or <b>[hilbert~]</b>).
 Like any other Pd patch, an abstraction may contain any kind of objects
 (internals, compiled externals and even other abstractions).
 
@@ -535,30 +535,30 @@ a library".
 
 <H3> <A id=s4.4>4.4. Loading externals </A> </H3>
 
-<p>The current best practice is to use the [declare] object to search for,
+<p>The current best practice is to use the <b>[declare]</b> object to search for,
 load and manage externals, but there are alternatives.
 
 <p>If the object is from a library that is distributed as a single binary pack,
 this binary needs to be pre loaded at start time by Pd, so it can create its
-externals. This is done either with [declare] or manually via the 'Startup' tab
+externals. This is done either with <b>[declare]</b> or manually via the 'Startup' tab
 in Preferences.
 
 <p>If the external library only contains abstractions or objects compiled as
 a set of separate binaries, Pd just needs to know its path. Again, this can be
-done via [declare] or manually via the 'Path' tab in Preferences, but yet
+done via <b>[declare]</b> or manually via the 'Path' tab in Preferences, but yet
 another option here is to use slash declarations as we'll see later.
 
-<H4> <A id=s4.4.1>4.4.1. Using the [declare] object</A> </H4>
+<H4> <A id=s4.4.1>4.4.1. Using the <b>[declare]</b> object</A> </H4>
 
-<p>The [declare] object can be used to add search paths or load libraries. When
+<p>The <b>[declare]</b> object can be used to add search paths or load libraries. When
 adding a path, it behaves quite similarly to adding search paths to the
 user added paths via the 'Path' tab in Preferences. The difference is that this
-will only work for the patch that contains this [declare] object - unlike using
+will only work for the patch that contains this <b>[declare]</b> object - unlike using
 Path preferences, which loads the path(s) permanently for any patch.
 
-<p>As for loading a library, once Pd loads it (via [declare] or startup) it
-sticks with it. This means that if you use [declare] to load a library, it will
-also be loaded if you create a new patch without any [declare] object.
+<p>As for loading a library, once Pd loads it (via <b>[declare]</b> or startup) it
+sticks with it. This means that if you use <b>[declare]</b> to load a library, it will
+also be loaded if you create a new patch without any <b>[declare]</b> object.
 
 <H5> <A id=s4.4.1.1>4.4.1.1. [declare -path]</A> </H5>
 
@@ -577,9 +577,9 @@ User Added Paths and Standard Paths. So let’s say you put the ELSE library fol
 for it there and will find it!
 
 <p> Now, in the case of a single external, the best practice is to include it in
-a folder with the same name in “~/Documents/Pd/externals”. An example, the [freeverb~]
+a folder with the same name in “~/Documents/Pd/externals”. An example, the <b>[freeverb~]</b>
 external should be in “~/Documents/Pd/externals/freeverb~”. In this situation, you don’t
-need to add the external folder to the path, manually or use [declare]. This is because
+need to add the external folder to the path, manually or use <b>[declare]</b>. This is because
 when you tell Pd to look for an external, if it finds a folder with the same name as the
 external, it'll know to search inside that folder for the external!
 
@@ -590,11 +590,11 @@ is a single binary pack with many externals. One such example is the
 <a href="https://git.iem.at/pd/zexy/"> Zexy </a> library. So you should
 download and have the 'zexy' folder in “~/Documents/Pd/externals/zexy”.
 Now you can use [declare -lib zexy] to load the external binary. In the
-same way as explained with the [freeverb~] example, the binary is inside
+same way as explained with the <b>[freeverb~]</b> example, the binary is inside
 a folder with the same name. So Pd will search for the external in
 “~/Documents/Pd/externals", will find the 'zexy' folder and know to
 search for the zexy binary in it. This means you don't need to bother in
-using [declare] to define the search path.
+using <b>[declare]</b> to define the search path.
 
 <p>Note that it may be possible for you to load a library binary as an object
 if the developer wished to. But it's still advisable to use either "Startup"
@@ -605,28 +605,28 @@ before Pd tries to create other objects in your patch.
 a very special case as this binary does not actually load any external. What
 it actually loads are some .tcl plugins that add an object browser at right
 clicking on a patch canvas. It also prints information about the release on
-the Console window. Moreover, you can also load [else] as an object in a patch
+the Console window. Moreover, you can also load <b>[else]</b> as an object in a patch
 and it offers the functionality of outputting its version for you to check in
 the patch if it is the correct one.
 
-<p>The Cyclone library also allows you to load [cyclone] as an object and
+<p>The Cyclone library also allows you to load <b>[cyclone]</b> as an object and
 offers the same version output functionality as in ELSE.
 
-<p>For more details on how [declare] works, please check its help file!
+<p>For more details on how <b>[declare]</b> works, please check its help file!
 
 <H4> <A id=s4.4.2> 4.4.2. Load via path and startup</A> </H4>
 
-<p>We'll now see the differences between using [declare] or using "Path" and
+<p>We'll now see the differences between using <b>[declare]</b> or using "Path" and
 "Startup" tabs in Preferences.
 
 <H5> <A id=s4.4.2.1> 4.4.2.1. User added path</A> </H5>
 
 <p>One big difference in adding a search path in 'Preferences' is that this
 permanently adds the path and works every time Pd starts and for any patch
-you open. When you use [declare], the path is loaded only for its owning
+you open. When you use <b>[declare]</b>, the path is loaded only for its owning
 patch and loaded abstractions. Moreover, if you have an abstraction with
 [declare -path], it'll only work for that abstraction and not the parent
-patch! Hence, [declare] allows a much better control and management of
+patch! Hence, <b>[declare]</b> allows a much better control and management of
 paths. But you may want to permanently add a path in your own system if
 you know exactly what you have and what you need.
 
@@ -639,7 +639,7 @@ on “Add newly installed libraries to Pd’s search Path”, which adds downloa
 libraries to the user added search paths (see picture above).
 
 <p>Note also that having a user added search path will not make it have search
-priority like it happens when you use [declare]. In this case, the path relative
+priority like it happens when you use <b>[declare]</b>. In this case, the path relative
 to the patch will have top priority!
 
 <H5> <A id=s4.4.2.2> 4.4.2.2. Startup</A> </H5>
@@ -662,7 +662,7 @@ path. There are many other examples in the picture above. One particularity
 <a href="https://github.com/umlaeute/Gem"> Gem </a> is that it also forces
 Pd to add its path to the search paths, which is needed for some abstractions
 and then you don’t need to bother adding it to the path. Note, however, that
-unlike using [declare], this does not enforce a top search priority! Hence,
+unlike using <b>[declare]</b>, this does not enforce a top search priority! Hence,
 for example, you may prefer to use [declare -path Gem -lib Gem] instead.
 
 <p>It all depends on the developer, but it is a common and good practice that
@@ -706,13 +706,13 @@ correct external.
 part of a single binary pack, unless the developer uses a workaround to add
 this possibility as alternative.
 
-<p>The issue with [declare] or adding a path to the user added paths is that
+<p>The issue with <b>[declare]</b> or adding a path to the user added paths is that
 it'll respect a search order. Whatever path is added first in the search list
 order has a priority, and where ever Pd finds an external first, it'll load
 it and stop searching elsewhere. Again, this kind of problem is not that
 common, but you can solve this with slash declarations. You may also be able
 to sort this issue by setting the desired order. This is quite easy in
-[declare] as which ever -path comes first in the list has a priority, so you
+<b>[declare]</b> as which ever -path comes first in the list has a priority, so you
 can try that if you want to avoid slash declarations when you run into this
 rare issue.
 
@@ -720,23 +720,23 @@ rare issue.
 pack libraries. The problem is that once they get loaded, all of its external
 objects are now part of Pd and have a priority in the search. Here's an
 example, the 'ceammc' library is a single binary pack and it included an
-object called [xfade~]. The ELSE library has separate binaries for each
-object and also has one called [xfade~]. If you're using both libraries,
-ceammc's [xfade~] object will have priority and it doesn't help you to have
+object called <b>[xfade~]</b>. The ELSE library has separate binaries for each
+object and also has one called <b>[xfade~]</b>. If you're using both libraries,
+ceammc's <b>[xfade~]</b> object will have priority and it doesn't help you to have
 [declare -path else].
 
 
 <p>It was mentioned how a library name prefix may also be possible in the
 context of single binary packs. The ceammc library offers this, so you can
-also load its [xfade~] object as [ceammc/xfade~]. But note that this still
-requires you to preload the binary (via startup or [declare]). The slash
+also load its <b>[xfade~]</b> object as <b>[ceammc/xfade~]</b>. But note that this still
+requires you to preload the binary (via startup or <b>[declare]</b>). The slash
 declaration here was only possible because the developer added the
 'ceammc/xfade~' name as an alternative option in the code. So it is just a
 hack to improve the limitation of Pd in handling namespaces. Another library
 that does this is Cyclone, which carries a sublibrary with 12 objects with
-non alphanumeric names, such as [>~]. By using the same trick, you can create
-the [>~] object as [cyclone/>~]. Another single binary pack library that has
-[>~] is zexy, so this way you can make sure you're getting cyclone's instead.
+non alphanumeric names, such as <b>[>~]</b>. By using the same trick, you can create
+the <b>[>~]</b> object as <b>[cyclone/>~]</b>. Another single binary pack library that has
+<b>[>~]</b> is zexy, so this way you can make sure you're getting cyclone's instead.
 
 <p>These issues might be clear if you better understand how Pd works when
 loading externals. See next subsection.
@@ -747,7 +747,7 @@ loading externals. See next subsection.
 happens when you create it. Whenever you create an object that Pd
 doesn't yet know about, Pd looks for the object file named as, for
 instance, "profile.pd_linux". Pd looks first in a path defined by
-[declare] (if any, of course), then in the directory containing
+<b>[declare]</b> (if any, of course), then in the directory containing
 the patch, then in directories listed as user added paths in the
 order they are listed, then in the standard paths. As soon as Pd
 finds the object in this search order, it'll stop searching further
@@ -757,7 +757,7 @@ object you asked for, and if everything is fine with it, this
 happens successfully (creation errors are given otherwise).
 
 <p>In the case of a single binary pack loaded at Startup or with
-[declare], all the externals it contains get preloaded in Pd's class
+<b>[declare]</b>, all the externals it contains get preloaded in Pd's class
 list, even though they're only created in object boxes when you
 require them.
 
@@ -779,15 +779,15 @@ reloaded!
 <H4> <A id=s4.5.1> 4.5.1. Overriding objects (externals and native)</A> </H4>
 
 <p>We've seen that Pd loads and sticks to an external binary,
-but they can get overridden. For instance, if you create [xfade~]
+but they can get overridden. For instance, if you create <b>[xfade~]</b>
 from ELSE and then load ceammc's binary later (that also has an
-[xfade~] object), Pd only knows about [xfade~] from ceammc! It's
+<b>[xfade~]</b> object), Pd only knows about <b>[xfade~]</b> from ceammc! It's
 been also noted how cyclone and zexy have objects with the same
 name. If you first load cyclone's binary and zexy's later, zexy's
-objects with the same name (such as [>~]) will override and prevail.
+objects with the same name (such as <b>[>~]</b>) will override and prevail.
 
 <p>And here's an interesting feature, you can also override internal
-objects with externals! Say you have an external called [phasor~].
+objects with externals! Say you have an external called <b>[phasor~]</b>.
 If it's a single binary, you can force Pd to find it with slash
 declarations. Otherwise, if it's a binary pack, you can load as any
 other library and if it has objects with the same name as vanilla's

--- a/doc/1.manual/x6.htm
+++ b/doc/1.manual/x6.htm
@@ -128,7 +128,7 @@ build Pd with debugging symbols using the "--enable-debug" flag.
 # build 64 bit Pd
 ./configure --with-universal=x86_64</pre>
 
-<p>You can compile a "Double precision" Pd (AKA: Pd64) with:</p>
+<p>You can compile a "Double precision" Pd (aka "Pd64") with:</p>
 
 <pre>./configure --with-floatsize=64</pre>
 


### PR DESCRIPTION
added 2.2.8 for scrollbars

i'm removing the span-formatting again here since it's useless for just adding the brackets and it disalllows copying from the manual (those css-inserted characters are not copied).

also considers:
* https://github.com/pure-data/pddp/issues/200
* https://github.com/pure-data/pddp/issues/201
* https://github.com/pure-data/pddp/issues/202
* https://github.com/pure-data/pddp/issues/203